### PR TITLE
set default socket timeout as 20s

### DIFF
--- a/lib/java/build.xml
+++ b/lib/java/build.xml
@@ -22,7 +22,7 @@
   
   <description>Thrift Build File</description>
   <property name="thrift.root" location="../../"/>
-  <property name="thrift.artifactid" value="libthrift"/>
+  <property name="thrift.artifactid" value="libthrift-revolution"/>
 
   <!-- Include the base properties file -->
   <property file="${basedir}/build.properties" />

--- a/lib/java/src/org/apache/thrift/transport/TServerSocket.java
+++ b/lib/java/src/org/apache/thrift/transport/TServerSocket.java
@@ -35,6 +35,7 @@ import java.net.SocketException;
 public class TServerSocket extends TServerTransport {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TServerSocket.class.getName());
+  private static final int DEFAULT_READ_TIMEOUT = 20000;
 
   /**
    * Underlying ServerSocket object
@@ -59,7 +60,7 @@ public class TServerSocket extends TServerTransport {
    * Creates a server socket from underlying socket object
    */
   public TServerSocket(ServerSocket serverSocket) throws TTransportException {
-    this(serverSocket, 0);
+    this(serverSocket, DEFAULT_READ_TIMEOUT);
   }
 
   /**
@@ -73,7 +74,7 @@ public class TServerSocket extends TServerTransport {
    * Creates just a port listening server socket
    */
   public TServerSocket(int port) throws TTransportException {
-    this(port, 0);
+    this(port, DEFAULT_READ_TIMEOUT);
   }
 
   /**
@@ -84,7 +85,7 @@ public class TServerSocket extends TServerTransport {
   }
 
   public TServerSocket(InetSocketAddress bindAddr) throws TTransportException {
-    this(bindAddr, 0);
+    this(bindAddr, DEFAULT_READ_TIMEOUT);
   }
 
   public TServerSocket(InetSocketAddress bindAddr, int clientTimeout) throws TTransportException {


### PR DESCRIPTION
There were two options to maintain this patch.

One is on hbase-thrift-1.0.0-cdh5.4.1.jar which is still being maintained on cloudera.
The other one is on libthrift.0.9.2.jar which was released on 2014-03-16 from Apache foundation.

For preventing any conflict from upgrading to newest CDH version, I made a small change on the second option.

cd thrift/lib/java/
./ant

will generate build/libthrift-repack-0.9.2.jar

then, copy this into /mnt/cloudera/parcels/CDH/jars on where thrift servers run.
then, replace symbolic link on /mnt/cloudera/parcels/CDH/lib/hbase/lib/libthrift-0.9.2.jar to point this jar.

---

The problem was there's no socket timeout for idle sockets that are making workers pending.
It happens due to thread pool model which thrift server uses. (each connection occupies one worker until it release connection)

That wouldn't be a big issue on production because we are using connection pools.

After applying this patch, garbage connections that occupy workers without any requests will be closed within timeout(20 seconds).
Normal operaions on appserver and daemons that use connection pools would not be affected with this patch because connection pools will manage the health of established connections at an shorter interval than socket timeout on thrift server.
